### PR TITLE
adding personal command in #5 called MistyRavager

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ intents.message_content = True
 
 bot = commands.Bot(command_prefix = '-', intents = intents)
 
+separators= [":","-","="]
+
 @bot.event 
 async def on_ready():
   print('ready')
@@ -15,6 +17,34 @@ async def on_ready():
 async def hi(ctx):
   await ctx.send("Hello!!")
 
+# Discord ID: MistyRavager#2412 Github ID: MistyRavager  
+@bot.command()
+async def MistyRavager(ctx):
+  separators= [":","-","="]
+  discordIDs = []
+  with open("main.py","r") as f:
+      lines = f.readlines()
+      comments = [i.strip() for i in lines if i.strip()!= '' and i.strip()[0]=="#"]
+      for comment in comments:
+          sentence = comment.split()
+          for word in sentence:
+              if word.find("#") != -1:
+                  index = 0
+                  while (index < len(separators) and word.find(separators[index]) == -1 ):
+                      index+=1    
+                  if index == len(separators):
+                      if word[0]=="#":
+                          continue
+                      discordIDs.append(word)
+                  else :
+                      discordIDs.append(word.split(separators[index])[-1])
+  
+  res = ""
+  for i in discordIDs: 
+    res += i+" "
+  
+  await ctx.send("the following people have made a personal command:")
+  await ctx.send(res)
 start()
 
 token = ""  #token will be provided with the every claimed issue


### PR DESCRIPTION
Issue: 5

#### Short description of what this resolves:
The command MistyRavager goes through main.py and displays all the discord IDs that have contributed into making a personal command


#### Changes proposed in this pull request and/or Screenshots of changes:

- Assumes the comments contain Discord IDs along with the tag number i.e. some_username#1234 (can add regex check in future)